### PR TITLE
Input handling adjustments

### DIFF
--- a/Globals/conductor.gd
+++ b/Globals/conductor.gd
@@ -9,6 +9,7 @@ signal quarter_beat(beat_num: int)
 @onready var sfx_test := $SFXTest
 
 # Drum stick sound on each quarter-note, for debug.
+@export var metronome_on: bool = true
 @export var debug_mode: bool = false
 
 
@@ -75,8 +76,9 @@ func update_beat_info() -> void:
 		# Emit signal for game events that happen on the quarter-note pulse
 		quarter_beat.emit(beat_number)
 		# Quarter note pulse, for debug
-		if debug_mode: 
+		if metronome_on: 
 			sfx_test.play()
+		if debug_mode:
 		# Debug output.
 			var inaccuracy_in_ms = (playback_time_in_secs - beats_passed_in_secs) * 1000
 			print("Beat ", beat_number)

--- a/Levels/Fantasy.tscn
+++ b/Levels/Fantasy.tscn
@@ -56,6 +56,7 @@ tile_set = SubResource("TileSet_atj3u")
 unique_name_in_owner = true
 z_index = 1
 position = Vector2(339, 244)
+debug_timing_info = true
 
 [node name="HUD" parent="." instance=ExtResource("8_4rhck")]
 unique_name_in_owner = true

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -41,6 +41,14 @@ var directions: Dictionary = { # Directions the player can go in
 
 # Player Visual Modifications to AnimatedSprite2D
 const original_modulate: Color = Color(1, 1, 1)  # White (default color)
+# Colors for each level of charge. 0-index is original color (white)
+const CHARGE_COLORS = [
+	Color(1, 1, 1),
+	Color(1, 0.65, 0), 
+	Color(1, 0.2, 0.2),
+	Color(0, 0.8, 1), 
+]
+
 const max_color: Color = Color(0, 0, 1) # Blue. TODO: choose a better color to change to
 
 ## COMMENTED OUT: Double tap variables
@@ -158,10 +166,18 @@ func move_to_end(direction: Vector2):
 ### VISUAL EFFECTS CODE
 # Function to update the player's color based on beats held
 func update_color(duration: float):
-	# Blend from original_modulate to max_color
-	var intensity = duration / (3.0 * Conductor.seconds_per_quarter_note)
-	intensity = clamp(intensity, 0, 1)  # Adjust "10.0" for max beats
-	player_sprite.modulate = original_modulate.lerp(max_color, intensity)
+	# Derive charges by comparing held duration to 
+	var num_charges: float = duration / Conductor.seconds_per_quarter_note
+	# Using decimal remainder lets us cycle intensity from 0 to 0.99 very charge.
+	var intensity = num_charges - floori(num_charges) if num_charges < MAX_CHARGES else 1
+	# We want the scale to cycle from 0-1, 0-1, 0-1 three times
+	# Each time, we will change the target modulate color
+	var next = min(MAX_CHARGES, int(num_charges)+1)
+	var curr = max(0, next-1)
+	var target_color = CHARGE_COLORS[next]
+	var curr_color = CHARGE_COLORS[curr]
+	intensity = ease(intensity, -1.8)
+	player_sprite.modulate = curr_color.lerp(target_color, intensity)
 
 
 ### TIMING/BEAT CODE:

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -39,17 +39,13 @@ var directions: Dictionary = { # Directions the player can go in
 		"move_down": {"dir": Vector2(0, 1), "held": 0.0},
 }
 
-# Player Visual Modifications to AnimatedSprite2D
-const original_modulate: Color = Color(1, 1, 1)  # White (default color)
-# Colors for each level of charge. 0-index is original color (white)
+# Colors for each level of charge.
 const CHARGE_COLORS = [
-	Color(1, 1, 1),
+	Color(1, 1, 1), # 0-index is original modulate
 	Color(1, 0.65, 0), 
 	Color(1, 0.2, 0.2),
 	Color(0, 0.8, 1), 
 ]
-
-const max_color: Color = Color(0, 0, 1) # Blue. TODO: choose a better color to change to
 
 ## COMMENTED OUT: Double tap variables
 #var last_key = null
@@ -166,16 +162,16 @@ func move_to_end(direction: Vector2):
 ### VISUAL EFFECTS CODE
 # Function to update the player's color based on beats held
 func update_color(duration: float):
-	# Derive charges by comparing held duration to 
+	# Derive charges by comparing held duration to known beat duration
 	var num_charges: float = duration / Conductor.seconds_per_quarter_note
-	# Using decimal remainder lets us cycle intensity from 0 to 0.99 very charge.
+	# Decimal remainder lets us cycle intensity from 0 to 0.99 between every change.
 	var intensity = num_charges - floori(num_charges) if num_charges < MAX_CHARGES else 1
-	# We want the scale to cycle from 0-1, 0-1, 0-1 three times
-	# Each time, we will change the target modulate color
-	var next = min(MAX_CHARGES, int(num_charges)+1)
-	var curr = max(0, next-1)
+	# Two adjacent indices in CHARGE_COLORS
+	var next = min(1+int(num_charges), MAX_CHARGES)
+	var curr = next-1
 	var target_color = CHARGE_COLORS[next]
 	var curr_color = CHARGE_COLORS[curr]
+	# < -1.0 parameter is ease-in-out
 	intensity = ease(intensity, -1.8)
 	player_sprite.modulate = curr_color.lerp(target_color, intensity)
 
@@ -185,7 +181,7 @@ func update_color(duration: float):
 func _on_quarter_beat(_beat_num):
 	pass
 
-
+# Evaluate how well player timed an input (presses and long releases)
 func handle_input_timing():
 	# Subtract one because beats are 1-indexed
 	var prev_beat_in_secs = (Conductor.num_beats_passed-1) * Conductor.seconds_per_quarter_note
@@ -198,19 +194,17 @@ func handle_input_timing():
 	var close_enough = after_prev <= LEEWAY_IN_SECS or before_next <= LEEWAY_IN_SECS
 
 	if close_enough:
-		# TODO: Do stuff here. Recover health, increase combo, etc.
+		# TODO: Do stuff here (maybe a signal). Recover health, increase combo, etc.
 		pass
 	else:
-		# TODO: Do stuff here. Lose health, reset combo, etc.
+		# TODO: Do stuff here (maybe a signal). Lose health, reset combo, etc.
 		pass
 			
 	if debug_timing_info:
-		var result = "GOOD!" if close_enough else "Bad."
+		var result = "Good!" if close_enough else "BAD."
 		var min_error = min(after_prev, before_next) * 1000
 		print(result + " Within {error} ms of beat".format({"error": "%0.2f" % min_error})) 
 	
-	
-
 
 ### COMMENTED OUT: DOUBLE TAP MOVEMENT CODE
 # Detect if the player double tapped, an call a double tap func

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -24,7 +24,7 @@ const TILES_PER_CHARGE: int = 3
 # Duration to distinguish the releases of short taps vs intentional sustained taps
 const MIN_HOLD_DURATION: float = 0.35
 # Allow inputs to be timed earlier/later than the beat by this amount
-const LEEWAY_IN_SECS: float = 0.15
+const LEEWAY_IN_SECS: float = 0.15 # TODO: Allow calibration.
 
 ## Player propertes
 const PLAYER_SIZE: int = 32
@@ -171,21 +171,29 @@ func _on_quarter_beat(_beat_num):
 
 
 func handle_input_timing():
+	# Subtract one because beats are 1-indexed
 	var prev_beat_in_secs = (Conductor.num_beats_passed-1) * Conductor.seconds_per_quarter_note
 	var input_time = Conductor.current_time_in_secs
 	var next_beat_in_secs = prev_beat_in_secs + Conductor.seconds_per_quarter_note
 	
+	# Allow inputs slightly early/late relative to the most recent beat
 	var after_prev = abs(input_time - prev_beat_in_secs)
 	var before_next = abs(input_time - next_beat_in_secs)
-	
-	if !debug_timing_info:
-		return
-	
-	var min_error = min(after_prev, before_next) * 1000
-	if after_prev <= LEEWAY_IN_SECS or before_next <= LEEWAY_IN_SECS:
-		print("GOOD! Within {error} ms of beat".format({"error": "%0.2f" % min_error})) 
+	var close_enough = after_prev <= LEEWAY_IN_SECS or before_next <= LEEWAY_IN_SECS
+
+	if close_enough:
+		# TODO: Do stuff here. Recover health, increase combo, etc.
+		pass
 	else:
-		print("Bad. Within {error} ms of beat".format({"error": "%0.2f" % min_error})) 
+		# TODO: Do stuff here. Lose health, reset combo, etc.
+		pass
+			
+	if debug_timing_info:
+		var result = "GOOD!" if close_enough else "Bad."
+		var min_error = min(after_prev, before_next) * 1000
+		print(result + " Within {error} ms of beat".format({"error": "%0.2f" % min_error})) 
+	
+	
 
 
 ### COMMENTED OUT: DOUBLE TAP MOVEMENT CODE


### PR DESCRIPTION
Since we want to allow the player to time inputs _before_ the beat, it turns out that counting the beats that pass is not a good approach for managing the stages of sustained input (because the `quarter_beat` signal takes place at a point in time, not a range). Instead, we can derive the 'power' of the sustained input from how much time has passed since the input was first held (this is approximate, but seems to work well enough).

Additionally, the input queue didn't feel like an appropriate solution to helping players get back on track. Instead, I felt thrown off whenever the queue would cause the player to move autonomously. I decided to remove the queuing; as an alternative, we can aim to have good VFX/SFX to assist players when playing off-beat.

I liked the sprite color changes a lot, so I extended the feature to change to a different color between each outcome. It should help reinforce the separate stages of the sustained input.

Changes include:
- `held` is now a float representing how much time an input has been held for, instead of a boolean
- `count` has been removed from the `directions` objects
- Removed most time-related variables in favor of using variables managed by Conductor
- Removed input queue and related code
- Increased tiles travelled per charge from 2 to 3
- Only processing the first valid input direction encountered per frame (press > release > hold)
- Allow player to move completely freely (they will be punished for being off-beat in other non-movement ways)
