### PR TITLE
Tweaks to End Screens

### DIFF
--- a/Assets/Music/fantasy_1.mp3.import
+++ b/Assets/Music/fantasy_1.mp3.import
@@ -12,8 +12,8 @@ dest_files=["res://.godot/imported/fantasy_1.mp3-ee8910bfdd44b6f165bac2e4b88c8a2
 
 [params]
 
-loop=true
-loop_offset=0
-bpm=0
+loop=false
+loop_offset=0.0
+bpm=0.0
 beat_count=0
 bar_beats=4

--- a/Assets/Music/fantasy_2.mp3.import
+++ b/Assets/Music/fantasy_2.mp3.import
@@ -12,8 +12,8 @@ dest_files=["res://.godot/imported/fantasy_2.mp3-20d355322543bd5e7404ec6fddde7fd
 
 [params]
 
-loop=true
-loop_offset=0
-bpm=0
+loop=false
+loop_offset=0.0
+bpm=0.0
 beat_count=0
 bar_beats=4

--- a/Components/GameOver.tscn
+++ b/Components/GameOver.tscn
@@ -19,6 +19,7 @@ corner_radius_bottom_right = 15
 corner_radius_bottom_left = 15
 
 [node name="GameOver" type="Node2D"]
+z_index = 10
 
 [node name="Panel" type="Panel" parent="."]
 material = SubResource("CanvasItemMaterial_ko7wh")

--- a/Components/Victory.tscn
+++ b/Components/Victory.tscn
@@ -18,7 +18,8 @@ corner_radius_top_right = 15
 corner_radius_bottom_right = 15
 corner_radius_bottom_left = 15
 
-[node name="GameOver" type="Node2D"]
+[node name="Victory" type="Node2D"]
+z_index = 10
 
 [node name="Panel" type="Panel" parent="."]
 material = SubResource("CanvasItemMaterial_5w44s")

--- a/Globals/conductor.gd
+++ b/Globals/conductor.gd
@@ -3,6 +3,7 @@ extends Node
 
 # Emitted on every quarter beat
 signal quarter_beat(beat_num: int)
+signal song_finished
 
 # Type-inferred references for IntelliSense.
 @onready var music := $Music
@@ -102,7 +103,13 @@ func set_music(name: String) -> void:
 	music.stream = load(file_path)
 	seconds_per_quarter_note = convert_bpm_to_quarter_note_in_secs(song_to_play.bpm)
 	music.play()
+	music.finished.connect(_on_music_finished)
 	print("Playing song: \"", name, "\"\n")
+	
+
+func stop_music():
+	# TODO: Add a cool transition
+	music.stop()
 
 	
 # Returns how long audio has played for, in seconds.
@@ -126,3 +133,6 @@ func compute_playback_time() -> float:
 # Converts bpm into how long a quarter lasts, in seconds
 func convert_bpm_to_quarter_note_in_secs(bpm: int) -> float:
 	return 60.0 / bpm
+
+func _on_music_finished():
+	song_finished.emit()

--- a/Levels/Fantasy.gd
+++ b/Levels/Fantasy.gd
@@ -36,15 +36,15 @@ const WINNING_SCORE: int = 20
 # 	'args' is a dictionary of additional parameters to 'function'
 var timeline = [
 	{"time": 1, "function": "spawn_puddles_periodically", "args": {}},
-	{"time": 2, "function": "spawn_thunderstorm", "args": {}}
-	#{"time": 4, "function": "cleave", "args": {}}, # Test defaulting to West
-	#{"time": 8, "function": "cleave", "args": {"direction": "EAST"}},
-	#{"time": 12, "function": "cleave", "args": {"direction": "NORTH"}},
-	#{"time": 16, "function": "cleave", "args": {"direction": "SOUTH"}},
-	#{"time": 20, "function": "spawn_ghost_on_player", "args": {}},
-	#{"time": 24, "function": "spawn_ghost_on_player", "args": {}},
-	#{"time": 25, "function": "spawn_ghost_on_player", "args": {}},
-	#{"time": 30, "function": "spawn_ghost_on_player", "args": {}},
+	{"time": 2, "function": "spawn_thunderstorm", "args": {}},
+	{"time": 4, "function": "cleave", "args": {}}, # Test defaulting to West
+	{"time": 8, "function": "cleave", "args": {"direction": "EAST"}},
+	{"time": 12, "function": "cleave", "args": {"direction": "NORTH"}},
+	{"time": 16, "function": "cleave", "args": {"direction": "SOUTH"}},
+	{"time": 20, "function": "spawn_ghost_on_player", "args": {}},
+	{"time": 24, "function": "spawn_ghost_on_player", "args": {}},
+	{"time": 25, "function": "spawn_ghost_on_player", "args": {}},
+	{"time": 30, "function": "spawn_ghost_on_player", "args": {}},
 ]
 var next_event: int = 0
 
@@ -52,13 +52,19 @@ var next_event: int = 0
 func _ready() -> void:
 	# Declare a function to be executed whenever the quarter_beat signal is emitted
 	Conductor.quarter_beat.connect(_on_quarter_beat)
+	Conductor.song_finished.connect(_on_song_finished)
 	window_dimensions =  get_viewport_rect().size
 	
 	%Player.position = get_viewport_rect().get_center()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:
-	pass
+	# Check if the game is over. If player died, should happen instantly.
+	if GameState.life <= 0:
+		timeline = []
+		var game_over = GameOverComponent.instantiate()
+		add_child(game_over)
+		Conductor.stop_music()
 	
 
 # Function to be called whenever quarter_beat signal is emitted
@@ -75,18 +81,12 @@ func _on_quarter_beat(beat_num: int):
 		call(timeline[next_event].function, timeline[next_event].args)
 		next_event += 1
 
-
-	# Check if the game is over
-	if GameState.life <= 0:
-		timeline = []
-		var game_over = GameOverComponent.instantiate()
-		self.get_tree().root.get_node("Fantasy").add_child(game_over)
-		#TODO stop the conductor
-		
+func _on_song_finished():
+	# Only check score once song has finished (i.e. player must survive entire song)
 	if GameState.score >= WINNING_SCORE:
 		var victory = VictoryComponent.instantiate()
-		self.get_tree().root.get_node("Fantasy").add_child(victory)
-
+		add_child(victory)
+	
 
 func _on_eighth_beat(_beat_num: int):
 	pass

--- a/Levels/Fantasy.gd
+++ b/Levels/Fantasy.gd
@@ -53,19 +53,14 @@ func _ready() -> void:
 	# Declare a function to be executed whenever the quarter_beat signal is emitted
 	Conductor.quarter_beat.connect(_on_quarter_beat)
 	Conductor.song_finished.connect(_on_song_finished)
+	GameEvents.player_died.connect(_on_player_died)
 	window_dimensions =  get_viewport_rect().size
 	
 	%Player.position = get_viewport_rect().get_center()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:
-	# Check if the game is over. If player died, should happen instantly.
-	if GameState.life <= 0:
-		timeline = []
-		var game_over = GameOverComponent.instantiate()
-		add_child(game_over)
-		Conductor.stop_music()
-	
+	pass
 
 # Function to be called whenever quarter_beat signal is emitted
 func _on_quarter_beat(beat_num: int):
@@ -86,7 +81,13 @@ func _on_song_finished():
 	if GameState.score >= WINNING_SCORE:
 		var victory = VictoryComponent.instantiate()
 		add_child(victory)
-	
+
+func _on_player_died():
+	# TODO: Despawn player, stop processing input
+	timeline = []
+	var game_over = GameOverComponent.instantiate()
+	add_child(game_over)
+	Conductor.stop_music()
 
 func _on_eighth_beat(_beat_num: int):
 	pass


### PR DESCRIPTION
- Victory/score only checked when song ends (song should always play to the end; no early completion)
- Raised Z-index to 10 (arbitrarily high value), these overlays should be rendered above everything else
- Death is checked immediately, using `player_died` GameEvents signal instead of on quarter beats