### PR TITLE
Iterative projectile tweaks

### DIFF
--- a/EnemyAttacks/Projectiles/attack.tscn
+++ b/EnemyAttacks/Projectiles/attack.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://ixwndwmexdeb"]
 
-[ext_resource type="Texture2D" uid="uid://bwke0uchycnoa" path="res://Assets/Objects/orange_circle.png" id="1_j48wd"]
+[ext_resource type="Texture2D" uid="uid://ctwf8gqvrn22h" path="res://Assets/Themes/Fantasy/vines.png" id="1_fnnpm"]
 
 [node name="Sprite2D" type="Sprite2D"]
-texture = ExtResource("1_j48wd")
+texture = ExtResource("1_fnnpm")

--- a/EnemyAttacks/Projectiles/iterative_projectile.gd
+++ b/EnemyAttacks/Projectiles/iterative_projectile.gd
@@ -41,7 +41,11 @@ func start(input_direction: String, input_type: String, input_coords: PackedVect
 	set_direction(input_direction)
 	set_attack_type(input_type)
 	for i in range(input_coords.size()):
-		projectiles.append(generate_projectile.instantiate())
+		var projectile_attack = generate_projectile.instantiate()
+		# Keep references to projectile nodes
+		projectiles.append(projectile_attack)
+		# AND make sure to add them to the tree!! (as a child of this scene, IteractiveProjectile)
+		add_child(projectile_attack)
 		projectiles[i].start(direction, input_coords[i])
 		starting_coords.append(input_coords[i])
 	turn_count = input_turn_count
@@ -76,7 +80,11 @@ func start_one_coord(input_direction: String, input_type: String, input_coord: V
 	print("Projectile generated")
 	set_direction(input_direction)
 	set_attack_type(input_type)
-	projectiles.append(generate_projectile.instantiate())
+	var projectile_attack = generate_projectile.instantiate()
+	# Keep reference to projectile
+	projectiles.append(projectile_attack)
+	# AND add it to tree!!
+	add_child(projectile_attack)
 	projectiles[0].start(direction, input_coord)
 	starting_coords.append(input_coord)
 	turn_count = input_turn_count
@@ -111,7 +119,8 @@ func start_one_coord(input_direction: String, input_type: String, input_coord: V
 #TODO: Make this based on beat, not time
 func update(beat_num: int) -> void:
 	for child in get_children():
-		if child is not Timer:
+		# Changed to remove sprites only (used to be 'not Timer')
+		if child is Sprite2D:
 			remove_child(child)
 	match type:
 		"STRAIGHT":

--- a/EnemyAttacks/Projectiles/iterative_projectile.gd
+++ b/EnemyAttacks/Projectiles/iterative_projectile.gd
@@ -37,14 +37,11 @@ func _ready() -> void:
 	$TelegraphTimer.timeout.connect(_on_telegraph_timer_timeout)
 
 func start(input_direction: String, input_type: String, input_coords: PackedVector2Array, input_turn_count: int):
-	print("Projectile generated")
 	set_direction(input_direction)
 	set_attack_type(input_type)
 	for i in range(input_coords.size()):
 		var projectile_attack = generate_projectile.instantiate()
-		# Keep references to projectile nodes
 		projectiles.append(projectile_attack)
-		# AND make sure to add them to the tree!! (as a child of this scene, IteractiveProjectile)
 		add_child(projectile_attack)
 		projectiles[i].start(direction, input_coords[i])
 		starting_coords.append(input_coords[i])
@@ -77,13 +74,10 @@ func start(input_direction: String, input_type: String, input_coords: PackedVect
 			add_scene($Telegraph, telegraph_image_tracking);
 
 func start_one_coord(input_direction: String, input_type: String, input_coord: Vector2, input_turn_count: int):
-	print("Projectile generated")
 	set_direction(input_direction)
 	set_attack_type(input_type)
 	var projectile_attack = generate_projectile.instantiate()
-	# Keep reference to projectile
 	projectiles.append(projectile_attack)
-	# AND add it to tree!!
 	add_child(projectile_attack)
 	projectiles[0].start(direction, input_coord)
 	starting_coords.append(input_coord)
@@ -116,7 +110,6 @@ func start_one_coord(input_direction: String, input_type: String, input_coord: V
 			add_scene($Telegraph, telegraph_image_tracking);
 
 # Called every beat.
-#TODO: Make this based on beat, not time
 func update(beat_num: int) -> void:
 	for child in get_children():
 		# Changed to remove sprites only (used to be 'not Timer')
@@ -247,7 +240,6 @@ func _on_telegraph_timer_timeout():
 	# Could be optimized to avoid adding more children
 	$Telegraph.visible = false
 	#add_scene(self)
-	# Connect to beat signal rather than using UpdateTimer
 	Conductor.quarter_beat.connect(update)
 	
 	

--- a/EnemyAttacks/Projectiles/iterative_projectile.gd
+++ b/EnemyAttacks/Projectiles/iterative_projectile.gd
@@ -35,8 +35,6 @@ var turn_count: int # Spinning projectiles only
 func _ready() -> void:
 	$TelegraphTimer.wait_time = telegraph_duration * Conductor.seconds_per_quarter_note
 	$TelegraphTimer.timeout.connect(_on_telegraph_timer_timeout)
-	$UpdateTimer.wait_time = Conductor.seconds_per_quarter_note
-	$UpdateTimer.timeout.connect(_on_update_timer_timeout)
 
 func start(input_direction: String, input_type: String, input_coords: PackedVector2Array, input_turn_count: int):
 	print("Projectile generated")
@@ -111,7 +109,7 @@ func start_one_coord(input_direction: String, input_type: String, input_coord: V
 
 # Called every beat.
 #TODO: Make this based on beat, not time
-func update() -> void:
+func update(beat_num: int) -> void:
 	for child in get_children():
 		if child is not Timer:
 			remove_child(child)
@@ -175,7 +173,6 @@ func update() -> void:
 							projectile.direction = "EAST"
 				projectile.move()
 				projectile.add_scene(self)
-	$UpdateTimer.start()
 
 # Adds courners to expanding projectiles
 func add_corners():
@@ -241,10 +238,9 @@ func _on_telegraph_timer_timeout():
 	# Could be optimized to avoid adding more children
 	$Telegraph.visible = false
 	#add_scene(self)
-	$UpdateTimer.start()
+	# Connect to beat signal rather than using UpdateTimer
+	Conductor.quarter_beat.connect(update)
 	
-func _on_update_timer_timeout():
-	update()
 	
 func add_scene(parent: Node2D, scene: PackedScene):
 	for projectile in projectiles:

--- a/EnemyAttacks/Projectiles/iterative_projectile.tscn
+++ b/EnemyAttacks/Projectiles/iterative_projectile.tscn
@@ -5,12 +5,12 @@
 [ext_resource type="PackedScene" uid="uid://crty55i4hkry8" path="res://EnemyAttacks/Projectiles/Telegraphs/arrow_east.tscn" id="3_3iylw"]
 [ext_resource type="PackedScene" uid="uid://cxxilvsrw8kin" path="res://EnemyAttacks/Projectiles/Telegraphs/arrow_north.tscn" id="4_m0qd5"]
 [ext_resource type="PackedScene" uid="uid://cq4tphgsccaws" path="res://EnemyAttacks/Projectiles/Telegraphs/arrow_south.tscn" id="5_lryb0"]
-[ext_resource type="PackedScene" uid="uid://caj36swymv0da" path="res://EnemyAttacks/Projectiles/Telegraphs/expanding.tscn" id="6_0pfvb"]
+[ext_resource type="PackedScene" path="res://EnemyAttacks/Projectiles/Telegraphs/expanding.tscn" id="6_0pfvb"]
 [ext_resource type="PackedScene" uid="uid://c7eyerkvjh8no" path="res://EnemyAttacks/Projectiles/iterative_projectile_attack.tscn" id="6_uho0d"]
-[ext_resource type="PackedScene" uid="uid://bm8ffvphvw2bu" path="res://EnemyAttacks/Projectiles/Telegraphs/spinning_west.tscn" id="7_1feid"]
-[ext_resource type="PackedScene" uid="uid://dhw7dermh0y86" path="res://EnemyAttacks/Projectiles/Telegraphs/spinning_east.tscn" id="8_k6vnp"]
-[ext_resource type="PackedScene" uid="uid://yc5fvg4rdt7p" path="res://EnemyAttacks/Projectiles/Telegraphs/spinning_north.tscn" id="9_pew24"]
-[ext_resource type="PackedScene" uid="uid://by3px2geipkq6" path="res://EnemyAttacks/Projectiles/Telegraphs/spinning_south.tscn" id="10_pligr"]
+[ext_resource type="PackedScene" path="res://EnemyAttacks/Projectiles/Telegraphs/spinning_west.tscn" id="7_1feid"]
+[ext_resource type="PackedScene" path="res://EnemyAttacks/Projectiles/Telegraphs/spinning_east.tscn" id="8_k6vnp"]
+[ext_resource type="PackedScene" path="res://EnemyAttacks/Projectiles/Telegraphs/spinning_north.tscn" id="9_pew24"]
+[ext_resource type="PackedScene" path="res://EnemyAttacks/Projectiles/Telegraphs/spinning_south.tscn" id="10_pligr"]
 [ext_resource type="PackedScene" uid="uid://233scfblkwon" path="res://EnemyAttacks/HalfRoomCleave/AlertSign.tscn" id="11_wg2fk"]
 
 [node name="IternativeProjectile" type="Node2D"]
@@ -28,9 +28,6 @@ telegraph_image_tracking = ExtResource("11_wg2fk")
 generate_projectile = ExtResource("6_uho0d")
 
 [node name="TelegraphTimer" type="Timer" parent="."]
-one_shot = true
-
-[node name="UpdateTimer" type="Timer" parent="."]
 one_shot = true
 
 [node name="Telegraph" type="Node2D" parent="."]

--- a/EnemyAttacks/Projectiles/iterative_projectile_attack.gd
+++ b/EnemyAttacks/Projectiles/iterative_projectile_attack.gd
@@ -16,7 +16,6 @@ func _ready() -> void:
 
 
 func start(input_direction: String, input_coord: Vector2):
-	print("Projectile generated")
 	direction = input_direction
 	coord = input_coord
 

--- a/EnemyAttacks/Projectiles/iterative_projectile_attack.gd
+++ b/EnemyAttacks/Projectiles/iterative_projectile_attack.gd
@@ -56,5 +56,5 @@ func generate_collision_area():
 	rect_shape.size = dimension
 	collision_shape.set_shape(rect_shape)
 	$HitZone.add_child(collision_shape)
-	$HitZone.position.x = coord.x * TILE_SIZE
-	$HitZone.position.y = coord.y * TILE_SIZE
+	$HitZone.position.x = coord.x * TILE_SIZE + TILE_SIZE / 2
+	$HitZone.position.y = coord.y * TILE_SIZE + TILE_SIZE / 2

--- a/Levels/Fantasy.gd
+++ b/Levels/Fantasy.gd
@@ -7,6 +7,7 @@ extends Node2D
 @export var spawn_ghost: PackedScene
 @export var puddle_hazard: PackedScene
 @export var thunderstorm: PackedScene
+@export var iterative_projectile: PackedScene
 
 @export var debug_random_test: bool = false
 var GameOverComponent = preload("res://Components/GameOver.tscn")
@@ -36,7 +37,11 @@ const WINNING_SCORE: int = 20
 # 	'args' is a dictionary of additional parameters to 'function'
 var timeline = [
 	{"time": 1, "function": "spawn_puddles_periodically", "args": {}},
-	{"time": 2, "function": "spawn_thunderstorm", "args": {}},
+	#{"time": 2, "function": "spawn_thunderstorm", "args": {}},
+	{"time": 2, "function": "spawn_vines", "args": {"direction": "NORTH", "coord_x": 10, "coord_y": 7}},
+	{"time": 2, "function": "spawn_vines", "args": {"direction": "EAST", "coord_x": 10, "coord_y": 7}},
+	{"time": 2, "function": "spawn_vines", "args": {"direction": "WEST", "coord_x": 10, "coord_y": 7}},
+	{"time": 2, "function": "spawn_vines", "args": {"direction": "SOUTH", "coord_x": 10, "coord_y": 7}},
 	#{"time": 4, "function": "cleave", "args": {}}, # Test defaulting to West
 	#{"time": 8, "function": "cleave", "args": {"direction": "EAST"}},
 	#{"time": 12, "function": "cleave", "args": {"direction": "NORTH"}},
@@ -73,9 +78,11 @@ func _on_quarter_beat(beat_num: int):
 		return
 	
 	# Check if the next event in timeline queue should start
-	if int(floor(Conductor.num_beats_passed)) == timeline[next_event].time:
+	while int(floor(Conductor.num_beats_passed)) == timeline[next_event].time:
 		call(timeline[next_event].function, timeline[next_event].args)
 		next_event += 1
+		if next_event >= len(timeline):
+			break
 
 func _on_song_finished():
 	# Only check score once song has finished (i.e. player must survive entire song)
@@ -127,6 +134,33 @@ func spawn_ghost_on_player(args: Dictionary):
 	
 func spawn_puddles_periodically(args: Dictionary):
 	Conductor.quarter_beat.connect(_on_quarter_beat_spawn_puddle)
+	
+func spawn_vines(args: Dictionary):
+	var projectile = iterative_projectile.instantiate()
+	var type  = args.type if args.has("type") else ""
+	var direction  = args.direction if args.has("direction") else ""
+	var turn_count = int(args.turn) if args.has("turn") else 0
+	var coords
+	if (args.has("coord1_x") && args.has("coord1_y")):
+		coords = PackedVector2Array()
+		coords.append(Vector2(int(args.coord1_x), int(args.coord1_y)))
+		if (args.has("coord2_x") && args.has("coord2_y")):
+			coords.append(Vector2(int(args.coord2_x), int(args.coord2_y)))
+			if (args.has("coord3_x") && args.has("coord3_y")):
+				coords.append(Vector2(int(args.coord3_x), int(args.coord3_y)))
+				if (args.has("coord4_x") && args.has("coord4_y")):
+					coords.append(Vector2(int(args.coord4_x), int(args.coord4_y)))
+					if (args.has("coord5_x") && args.has("coord5_y")):
+						coords.append(Vector2(int(args.coord5_x), int(args.coord5_y)))
+		add_child(projectile)
+		projectile.start(direction, type, coords, turn_count)
+		return
+	elif (args.has("coord_x") && args.has("coord_y")):
+		coords = Vector2(int(args.coord_x), int(args.coord_y))
+	else:
+		coords = Vector2(0, 0)
+	add_child(projectile)
+	projectile.start_one_coord(direction, type, coords, turn_count)
 
 func _on_quarter_beat_spawn_puddle(beat_num: int):
 	# Only every eight beats, starting on beat two

--- a/Levels/Fantasy.gd
+++ b/Levels/Fantasy.gd
@@ -36,7 +36,7 @@ const WINNING_SCORE: int = 20
 #   'function' is the name of a function in this script; must be in quotation marks
 # 	'args' is a dictionary of additional parameters to 'function'
 var timeline = [
-	{"time": 1, "function": "spawn_puddles_periodically", "args": {}},
+	#{"time": 1, "function": "spawn_puddles_periodically", "args": {}},
 	#{"time": 2, "function": "spawn_thunderstorm", "args": {}},
 	{"time": 2, "function": "spawn_vines", "args": {"direction": "NORTH", "coord_x": 10, "coord_y": 7}},
 	{"time": 2, "function": "spawn_vines", "args": {"direction": "EAST", "coord_x": 10, "coord_y": 7}},

--- a/Levels/Fantasy.gd
+++ b/Levels/Fantasy.gd
@@ -172,6 +172,7 @@ func spawn_vines(args: Dictionary):
 	add_child(projectile)
 	projectile.start_one_coord(direction, type, coords, turn_count)
 
+
 func _on_quarter_beat_spawn_puddle(beat_num: int):
 	# Only every eight beats, starting on beat two
 	if floori(Conductor.num_beats_passed) % 8 != 2:

--- a/Levels/Fantasy.gd
+++ b/Levels/Fantasy.gd
@@ -23,7 +23,7 @@ const WINNING_SCORE: int = 20
 
 #const TILES = {
 	#"RED": {"src": 2, "atlas": Vector2(0,0), "alt": 3},
-	#"DANGER": {"src": 3, "atlas": Vector2(0, 0), "alt": 0},
+	#"DANGER": {"src": 3, "atlas": eVector2(0, 0), "alt": 0},
 	#"FLOOR_DARK": {"src": 1, "atlas": Vector2(0,0), "alt": 3},
 	#"FLOOR_MED": {"src": 1, "atlas": Vector2(0,0), "alt": 1},
 	#"FLOOR_LIGHT": {"src": 1, "atlas": Vector2(0,0), "alt": 0},
@@ -38,10 +38,7 @@ const WINNING_SCORE: int = 20
 var timeline = [
 	#{"time": 1, "function": "spawn_puddles_periodically", "args": {}},
 	#{"time": 2, "function": "spawn_thunderstorm", "args": {}},
-	{"time": 2, "function": "spawn_vines", "args": {"direction": "NORTH", "coord_x": 10, "coord_y": 7}},
-	{"time": 2, "function": "spawn_vines", "args": {"direction": "EAST", "coord_x": 10, "coord_y": 7}},
-	{"time": 2, "function": "spawn_vines", "args": {"direction": "WEST", "coord_x": 10, "coord_y": 7}},
-	{"time": 2, "function": "spawn_vines", "args": {"direction": "SOUTH", "coord_x": 10, "coord_y": 7}},
+	{"time": 2, "function": "spawn_vines_in_cross_pattern", "args": {}},
 	#{"time": 4, "function": "cleave", "args": {}}, # Test defaulting to West
 	#{"time": 8, "function": "cleave", "args": {"direction": "EAST"}},
 	#{"time": 12, "function": "cleave", "args": {"direction": "NORTH"}},
@@ -135,6 +132,19 @@ func spawn_ghost_on_player(args: Dictionary):
 func spawn_puddles_periodically(args: Dictionary):
 	Conductor.quarter_beat.connect(_on_quarter_beat_spawn_puddle)
 	
+
+func spawn_vines_in_cross_pattern(args: Dictionary):
+	# TODO: Parameterize to allow non-central position
+	var calls = [
+		{"direction": "NORTH", "coord_x": 10, "coord_y": 7},
+		{"direction": "EAST", "coord_x": 10, "coord_y": 7},
+		{"direction": "WEST", "coord_x": 10, "coord_y": 7},
+		{"direction": "SOUTH", "coord_x": 10, "coord_y": 7}
+	]
+	for spawn_vines_args in calls:
+		call("spawn_vines", spawn_vines_args)
+	
+
 func spawn_vines(args: Dictionary):
 	var projectile = iterative_projectile.instantiate()
 	var type  = args.type if args.has("type") else ""

--- a/Levels/Fantasy.tscn
+++ b/Levels/Fantasy.tscn
@@ -41,6 +41,7 @@ half_room_cleave = ExtResource("2_5na7h")
 spawn_ghost = ExtResource("3_akj2n")
 puddle_hazard = ExtResource("10_t46jv")
 thunderstorm = ExtResource("5_5lko7")
+iterative_projectile = ExtResource("13_11hjv")
 debug_random_test = true
 
 [node name="ProjectileSpawner" parent="." instance=ExtResource("4_p1dld")]

--- a/Levels/Fantasy.tscn
+++ b/Levels/Fantasy.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=19 format=4 uid="uid://cnb7x1pkr34a4"]
+[gd_scene load_steps=18 format=4 uid="uid://cnb7x1pkr34a4"]
 
 [ext_resource type="Script" path="res://Levels/Fantasy.gd" id="1_qvkh8"]
 [ext_resource type="PackedScene" uid="uid://clu4w56s8h1yo" path="res://EnemyAttacks/HalfRoomCleave/HalfRoomCleave.tscn" id="2_5na7h"]
 [ext_resource type="PackedScene" uid="uid://dwhhs4cspt0f" path="res://EnemyAttacks/SpawnGhost/SpawnGhost.tscn" id="3_akj2n"]
 [ext_resource type="Texture2D" uid="uid://d2tkgid7kqj0d" path="res://Assets/Themes/Fantasy/fantasy_tile.png" id="4_jguqk"]
-[ext_resource type="PackedScene" uid="uid://bomiqmq23yxw5" path="res://EnemyAttacks/Projectiles/projectile_spawner.tscn" id="4_p1dld"]
 [ext_resource type="PackedScene" uid="uid://coodvgreajv2t" path="res://EnemyAttacks/LightningStrike/Thunderstorm.tscn" id="5_5lko7"]
 [ext_resource type="PackedScene" uid="uid://b0yyqdkpueu2n" path="res://TileManager/TileManager.tscn" id="5_asoik"]
 [ext_resource type="Texture2D" uid="uid://dtpt4up38l8d4" path="res://Assets/Themes/Fantasy/fantasy_floor.png" id="5_wbmv1"]
@@ -44,8 +43,6 @@ thunderstorm = ExtResource("5_5lko7")
 iterative_projectile = ExtResource("13_11hjv")
 debug_random_test = true
 
-[node name="ProjectileSpawner" parent="." instance=ExtResource("4_p1dld")]
-
 [node name="TileManager" parent="." instance=ExtResource("5_asoik")]
 unique_name_in_owner = true
 z_index = 0
@@ -80,6 +77,3 @@ scale = Vector2(1.8, 1.4)
 [node name="BossStaff" parent="." instance=ExtResource("11_hxj16")]
 z_index = 3
 position = Vector2(381, 156.8)
-
-[node name="IternativeProjectile" parent="." instance=ExtResource("13_11hjv")]
-position = Vector2(175, 140)

--- a/Prototyping/Example/iterative_projectile_testing.gd
+++ b/Prototyping/Example/iterative_projectile_testing.gd
@@ -18,16 +18,17 @@ const VER_TILES: int = HEIGHT / TILE_SIZE
 #   'function' is the name of a function in this script; must be in quotation marks
 # 	'args' is a dictionary of additional parameters to 'function'
 var timeline = [
-	{"time": 12, "function": "spawn_projectile_at_position", "args": {"coord_x": 5, "coord_y": 6}},
-	{"time": 16, "function": "spawn_projectile_at_position", "args": {"direction": "NORTH", "coord_x": 3, "coord_y": 5}},
-	{"time": 20, "function": "spawn_projectile_at_position", "args": {"direction": "SOUTH", "coord1_x": 15, "coord1_y": 5, "coord2_x": 16, "coord2_y": 5, "coord3_x": 17, "coord3_y": 5}},
-	{"time": 24, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "coord1_x": 7, "coord1_y": 5, "coord2_x": 9, "coord2_y": 9}},
-	{"time": 40, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "EXPANDING", "coord_x": 5, "coord_y": 5}},
-	{"time": 60, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "SPINNING", "turn": "4", "coord_x": 5, "coord_y": 5}},
-	{"time": 64, "function": "spawn_projectile_at_position", "args": {"direction": "NORTH", "type": "SPINNING", "turn": "3", "coord_x": 5, "coord_y": 7}},
-	{"time": 68, "function": "spawn_projectile_at_position", "args": {"direction": "SOUTH", "type": "SPINNING", "turn": "7", "coord_x": 15, "coord_y": 3}},
-	{"time": 72, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "SPINNING", "coord_x": 7, "coord_y": 4}},
-	{"time": 78, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "TRACKING", "coord_x": 10, "coord_y": 10}},
+	{"time": 4, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "EXPANDING", "coord_x": 5, "coord_y": 5}},
+	#{"time": 12, "function": "spawn_projectile_at_position", "args": {"coord_x": 5, "coord_y": 6}},
+	#{"time": 16, "function": "spawn_projectile_at_position", "args": {"direction": "NORTH", "coord_x": 3, "coord_y": 5}},
+	#{"time": 20, "function": "spawn_projectile_at_position", "args": {"direction": "SOUTH", "coord1_x": 15, "coord1_y": 5, "coord2_x": 16, "coord2_y": 5, "coord3_x": 17, "coord3_y": 5}},
+	#{"time": 24, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "coord1_x": 7, "coord1_y": 5, "coord2_x": 9, "coord2_y": 9}},
+	#{"time": 40, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "EXPANDING", "coord_x": 5, "coord_y": 5}},
+	#{"time": 60, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "SPINNING", "turn": "4", "coord_x": 5, "coord_y": 5}},
+	#{"time": 64, "function": "spawn_projectile_at_position", "args": {"direction": "NORTH", "type": "SPINNING", "turn": "3", "coord_x": 5, "coord_y": 7}},
+	#{"time": 68, "function": "spawn_projectile_at_position", "args": {"direction": "SOUTH", "type": "SPINNING", "turn": "7", "coord_x": 15, "coord_y": 3}},
+	#{"time": 72, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "SPINNING", "coord_x": 7, "coord_y": 4}},
+	#{"time": 78, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "TRACKING", "coord_x": 10, "coord_y": 10}},
 ]
 var next_event: int = 0
 
@@ -38,6 +39,7 @@ func _ready() -> void:
 	window_dimensions =  get_viewport_rect().size
 	
 	%Player.position = get_viewport_rect().get_center()
+	Conductor.set_music("Supernatural1")
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:

--- a/Prototyping/Example/iterative_projectile_testing.gd
+++ b/Prototyping/Example/iterative_projectile_testing.gd
@@ -19,16 +19,16 @@ const VER_TILES: int = HEIGHT / TILE_SIZE
 # 	'args' is a dictionary of additional parameters to 'function'
 var timeline = [
 	{"time": 4, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "EXPANDING", "coord_x": 5, "coord_y": 5}},
-	#{"time": 12, "function": "spawn_projectile_at_position", "args": {"coord_x": 5, "coord_y": 6}},
-	#{"time": 16, "function": "spawn_projectile_at_position", "args": {"direction": "NORTH", "coord_x": 3, "coord_y": 5}},
-	#{"time": 20, "function": "spawn_projectile_at_position", "args": {"direction": "SOUTH", "coord1_x": 15, "coord1_y": 5, "coord2_x": 16, "coord2_y": 5, "coord3_x": 17, "coord3_y": 5}},
-	#{"time": 24, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "coord1_x": 7, "coord1_y": 5, "coord2_x": 9, "coord2_y": 9}},
-	#{"time": 40, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "EXPANDING", "coord_x": 5, "coord_y": 5}},
-	#{"time": 60, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "SPINNING", "turn": "4", "coord_x": 5, "coord_y": 5}},
-	#{"time": 64, "function": "spawn_projectile_at_position", "args": {"direction": "NORTH", "type": "SPINNING", "turn": "3", "coord_x": 5, "coord_y": 7}},
-	#{"time": 68, "function": "spawn_projectile_at_position", "args": {"direction": "SOUTH", "type": "SPINNING", "turn": "7", "coord_x": 15, "coord_y": 3}},
-	#{"time": 72, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "SPINNING", "coord_x": 7, "coord_y": 4}},
-	#{"time": 78, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "TRACKING", "coord_x": 10, "coord_y": 10}},
+	{"time": 12, "function": "spawn_projectile_at_position", "args": {"coord_x": 5, "coord_y": 6}},
+	{"time": 16, "function": "spawn_projectile_at_position", "args": {"direction": "NORTH", "coord_x": 3, "coord_y": 5}},
+	{"time": 20, "function": "spawn_projectile_at_position", "args": {"direction": "SOUTH", "coord1_x": 15, "coord1_y": 5, "coord2_x": 16, "coord2_y": 5, "coord3_x": 17, "coord3_y": 5}},
+	{"time": 24, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "coord1_x": 7, "coord1_y": 5, "coord2_x": 9, "coord2_y": 9}},
+	{"time": 40, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "EXPANDING", "coord_x": 5, "coord_y": 5}},
+	{"time": 60, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "SPINNING", "turn": "4", "coord_x": 5, "coord_y": 5}},
+	{"time": 64, "function": "spawn_projectile_at_position", "args": {"direction": "NORTH", "type": "SPINNING", "turn": "3", "coord_x": 5, "coord_y": 7}},
+	{"time": 68, "function": "spawn_projectile_at_position", "args": {"direction": "SOUTH", "type": "SPINNING", "turn": "7", "coord_x": 15, "coord_y": 3}},
+	{"time": 72, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "SPINNING", "coord_x": 7, "coord_y": 4}},
+	{"time": 78, "function": "spawn_projectile_at_position", "args": {"direction": "WEST", "type": "TRACKING", "coord_x": 10, "coord_y": 10}},
 ]
 var next_event: int = 0
 


### PR DESCRIPTION
Debugged collision issues in `IterativeProjectile`
- Techniques to help debug collisions:
	- Enable 'Debug -> Visible Collision Shapes'
	- Pause the game and examine 'Remote' node tree. Check if tree looks like what we would expect.
- `IterativeProjectileAttacks` were being created and tracked in the `projectiles` list of `IterativeProjectile`, but were never added to the scene tree itself (missing `add_child` calls)
	- Adding missing calls to `start` and `start_one_coord`
- After adding missing `add_child` calls, the `IterativeProjectileAttacks` (and by extension, all `HitZones`) were being instantly removed by `update` in `IterativeProjectile` which removed all non-`Timer` children.
	- It now removes all `Sprite2D`, but this may not be the best solution
- Added `TILE_SIZE / 2` to center collision zones in middle of tiles in `IterativeProjectileAttack`
- Collision detection itself was perfectly fine!

---
Known issues/To-Do:
- Expanding projectile only has a collision zone for one image. 
	- One possible solution may be to have `HitZone` be a child of the `Sprite2D` root node of `attack.tscn`, instead of managing collision zones and images separately through code.
- Single-image projectiles should destroy themselves after hitting the player.
- Projectiles that don't hit a player should destroy themselves after they go off screen; currently, they live forever.

---
Style:
- `spawn_projectile_at_position` in `IterativeProjectileTesting` is really gnarly. I would probably refactor all the `coords` into a a single array of `Vector2` and discover them using a `for` loop instead of nested `if` statements.
- Managing references using the `projectiles` list may cause problems (e.g. needing to remove 'null' references to avoid calling `.move` on a projectile that has destroyed itself). It may be beneficial to replace the array with a reference to an empty Node2D child (e.g. `ProjectileContainer`) that is used as a folder to contain projectile children.
- If we had time to redesign the `IterativeProjectile` scene , I might separate the different projectile types into their own separate Scenes. But this is probably not worth doing, given our pending project deadline.